### PR TITLE
Pin importlib-metadata to 2.1.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest==4.6.11
 pytest-cov==2.12.0
 pytest-django==3.10.0
 pytest-pythonpath==0.7.3
+importlib-metadata==2.1.3


### PR DESCRIPTION
Because importlib-metadata latest release remove deprecated endpoint.

Fix: #30