### PR TITLE
Update pytest ecosystem

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 flake8==5.0.4
-pytest==4.6.11
-pytest-cov==2.12.0
-pytest-django==3.10.0
-pytest-pythonpath==0.7.3
+pytest==7.0.1
+pytest-cov==4.0.0
+pytest-django==4.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,5 @@ include_trailing_comma = True
 
 [tool:pytest]
 addopts = --cov=django_epflmisc --cov-report=term --cov-report=xml
-python_paths = tests/
+pythonpath = tests/
 DJANGO_SETTINGS_MODULE = settings

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,6 @@ multi_line_output = 3
 include_trailing_comma = True
 
 [tool:pytest]
-addopts = --cov=django_epflmisc --cov-report=term --cov-report=xml
+addopts = --cov=django_epflmisc --cov-report=term --cov-report=xml --cov-fail-under=90
 pythonpath = tests/
 DJANGO_SETTINGS_MODULE = settings


### PR DESCRIPTION
* pytest from 4.6.11 to 7.0.1
* pytest-cov from 2.12.0 to 4.0.0
* pytest-django from 3.10.0 to 4.5.2
* pytest-pythonpath removed

Close: #43